### PR TITLE
Updated export_try for more models and running via CL

### DIFF
--- a/export_trt.py
+++ b/export_trt.py
@@ -1,27 +1,46 @@
+import sys
+import os
 import torch
 import time
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+if current_dir not in sys.path:
+    sys.path.append(current_dir)
+
 from trt_utilities import Engine
 
-
 def export_trt(trt_path: str, onnx_path: str, use_fp16: bool):
-    engine = Engine(trt_path)
+    if not os.path.exists(onnx_path):
+        print(f"Skipping conversion: {onnx_path} not found.")
+        return False
+    
+    try:
+        engine = Engine(trt_path)
+        torch.cuda.empty_cache()
+        s = time.time()
+        ret = engine.build(
+            onnx_path,
+            use_fp16,
+            enable_preview=True,
+        )
+        e = time.time()
+        print(f"Time taken to build: {(e-s)} seconds")
+        return ret
+    except Exception as e:
+        print(f"Error converting {onnx_path}: {str(e)}")
+        return False
 
-    torch.cuda.empty_cache()
+# List of models to convert
+models = [
+    {"trt_path": "./codeformer.engine", "onnx_path": "./codeformer.onnx", "use_fp16": True},
+    {"trt_path": "./gfqgan.engine", "onnx_path": "./gfqgan.onnx", "use_fp16": False},
+    {"trt_path": "./gfpgan14.engine", "onnx_path": "./GFPGANv1.4.onnx", "use_fp16": False},
+    #{"trt_path": "./gpenbfr2048.engine", "onnx_path": "./GPEN-BFR-2048.onnx", "use_fp16": False}, - fails, boo
+]
 
-    s = time.time()
-    ret = engine.build(
-        onnx_path,
-        use_fp16,
-        enable_preview=True,
-    )
-    e = time.time()
-    print(f"Time taken to build: {(e-s)} seconds")
-
-    return ret
-
-
-export_trt(trt_path="./codeformer.engine",
-           onnx_path="./codeformer.onnx", use_fp16=True)
-           
-export_trt(trt_path="./gfqgan.engine",
-           onnx_path="./gfqgan.onnx", use_fp16=False)
+for model in models:
+    result = export_trt(**model)
+    if result:
+        print(f"Successfully converted {model['onnx_path']}")
+    else:
+        print(f"Failed to convert {model['onnx_path']}")


### PR DESCRIPTION
Hey, I don't know if this is something you want but I was playing with your code last night. I use ComfyUI standalone and like to run everything just via the CL and I think most Comfy people do as well, so I edited your script so that it will run via the CL without any special args, is easier to add more models to convert, and also doesn't error out if it can't find one.

In my testing I was actually getting better results with GFPG over GFQ. I tried to convert a GPEN and it failed, I don't know enough about tensorrt to understand why 😁

FWIW the way other models are converted requires changes to other code (due to result keys). I'm happy to share the changes I made to get GFPG to work but they are ugly and you can make much cleaner ones I'm sure.